### PR TITLE
Update configure_notebook.py

### DIFF
--- a/config/configure_notebook.py
+++ b/config/configure_notebook.py
@@ -59,7 +59,7 @@ with open('config/portfolio.txt', 'r') as f:
 
 import mlflow
 username = dbutils.notebook.entry_point.getDbutils().notebook().getContext().userName().get()
-mlflow.set_experiment('/Users/{}/esg_scoring'.format(username))
+mlflow.set_experiment('/Users/{}/esg-scoring'.format(username))
 
 # COMMAND ----------
 


### PR DESCRIPTION
Update `esg_scoring` to `esg-scoring` as the use of an `_` ends up failing the `mlflow.set_experiment()` call on some e2 instances.